### PR TITLE
Respect user choice of MAKE, AR and INSTALL in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # libutf8proc Makefile
 
 # programs
-MAKE=make
-AR=ar
-INSTALL=install
+MAKE?=make
+AR?=ar
+INSTALL?=install
 
 # compiler settings
 cflags = -O2 -std=c99 -pedantic -Wall -fpic -DUTF8PROC_EXPORTS $(CFLAGS)


### PR DESCRIPTION
Made the Makefile not overwrite the user's MAKE, AR and INSTALL variables.
Especially MAKE is important, since the file is not compatible with berkley make (because of the ifeq) and on FreeBSD GNU make is called gmake.