### PR TITLE
Do not export internal unsafe_encode_char()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ INSTALL=install
 CFLAGS ?= -O2
 PICFLAG = -fPIC
 C99FLAG = -std=c99
-UCFLAGS = $(CFLAGS) $(PICFLAG) $(C99FLAG) -DUTF8PROC_EXPORTS
+WCFLAGS = -Wall -Wmissing-prototypes -pedantic
+UCFLAGS = $(CFLAGS) $(PICFLAG) $(C99FLAG) $(WCFLAGS) -DUTF8PROC_EXPORTS
 
 # shared-library version MAJOR.MINOR.PATCH ... this may be *different*
 # from the utf8proc version number because it indicates ABI compatibility,

--- a/test/tests.h
+++ b/test/tests.h
@@ -33,7 +33,6 @@ size_t skipspaces(const char *buf, size_t i)
    separated by whitespace, and terminated by any character not in
    [0-9a-fA-F] or whitespace, then stores the corresponding utf8 string
    in dest, returning the number of bytes read from buf */
-utf8proc_ssize_t unsafe_encode_char(utf8proc_int32_t uc, utf8proc_uint8_t *dst);
 size_t encode(char *dest, const char *buf)
 {
      size_t i = 0, j, d = 0;
@@ -48,7 +47,7 @@ size_t encode(char *dest, const char *buf)
           }
           check(sscanf(buf + i, "%x", (unsigned int *)&c) == 1, "invalid hex input %s", buf+i);
           i = j; /* skip to char after hex input */
-          d += unsafe_encode_char(c, (utf8proc_uint8_t *) (dest + d));
+          d += utf8proc_encode_char(c, (utf8proc_uint8_t *) (dest + d));
      }
 }
 

--- a/utf8proc.c
+++ b/utf8proc.c
@@ -188,7 +188,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_encode_char(utf8proc_int32_t uc, ut
 }
 
 /* internal "unsafe" version that does not check whether uc is in range */
-utf8proc_ssize_t unsafe_encode_char(utf8proc_int32_t uc, utf8proc_uint8_t *dst) {
+static utf8proc_ssize_t unsafe_encode_char(utf8proc_int32_t uc, utf8proc_uint8_t *dst) {
    if (uc < 0x00) {
       return 0;
    } else if (uc < 0x80) {


### PR DESCRIPTION
This commit removes a spurious external symbol for the internal function `unsafe_encode_char()`, which I noticed while preparing a package of the utf8proc library for Debian.