### PR TITLE
Fix build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dylib
 *.dSYM
 *.out
+*.new
 data/*.txt
 data/*.ttf
 data/*.sfd
@@ -18,9 +19,9 @@ bench/icu
 bench/unistring
 normtest
 graphemetest
-utf8proc_data.c.new
 printproperty
 charwidth
 valid
 iterate
 case
+/tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get update -qq -y
     - sudo apt-get install libpcre3-dev julia fontforge -y
 script:
-    - make prefix=`pwd`/local install
+    - make manifest && diff MANIFEST.new MANIFEST
     - make check
     - make data && diff data/utf8proc_data.c.new utf8proc_data.c
     - make clean && git status --ignored --porcelain && test -z "$(git status --ignored --porcelain)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
     - make prefix=`pwd`/local install
     - make check
     - make data && diff data/utf8proc_data.c.new utf8proc_data.c
+    - make clean && git status --ignored --porcelain && test -z "$(git status --ignored --porcelain)"
     - (mkdir build_static && cd build_static && cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON && make)
     - (mkdir build_shared && cd build_shared && cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=ON && make)
 env:

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,7 @@
+include/
+include/utf8proc.h
+lib/
+lib/libutf8proc.a
+lib/libutf8proc.so -> libutf8proc.so.1.3.0
+lib/libutf8proc.so.1 -> libutf8proc.so.1.3.0
+lib/libutf8proc.so.1.3.0

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ all: libutf8proc.a libutf8proc.$(SHLIB_EXT)
 
 clean:
 	rm -f utf8proc.o libutf8proc.a libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.$(SHLIB_EXT) test/normtest test/graphemetest test/printproperty test/charwidth test/valid test/iterate
+ifneq ($(OS),Darwin)
+	rm -f libutf8proc.so.$(MAJOR)
+endif
 	$(MAKE) -C bench clean
 	$(MAKE) -C data clean
 
@@ -84,10 +87,9 @@ install: libutf8proc.a libutf8proc.$(SHLIB_EXT) libutf8proc.$(SHLIB_VERS_EXT)
 	mkdir -m 755 -p $(DESTDIR)$(libdir)
 	$(INSTALL) -m 644 libutf8proc.a $(DESTDIR)$(libdir)
 	$(INSTALL) -m 755 libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)
-	ln -f -s $(libdir)/libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.$(SHLIB_EXT)
+	ln -f -s libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.$(SHLIB_EXT)
 ifneq ($(OS),Darwin)
-	ln -f -s $(libdir)/libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.so.$(MAJOR)
-	ln -f -s $(libdir)/libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.so.$(MAJOR).$(MINOR)
+	ln -f -s libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.so.$(MAJOR)
 endif
 
 # Test programs

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,11 @@ includedir=$(prefix)/include
 all: libutf8proc.a libutf8proc.$(SHLIB_EXT)
 
 clean:
-	rm -f utf8proc.o libutf8proc.a libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.$(SHLIB_EXT) test/normtest test/graphemetest test/printproperty test/charwidth test/valid test/iterate
+	rm -f utf8proc.o libutf8proc.a libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.$(SHLIB_EXT)
 ifneq ($(OS),Darwin)
 	rm -f libutf8proc.so.$(MAJOR)
 endif
+	rm -f test/tests.o test/normtest test/graphemetest test/printproperty test/charwidth test/valid test/iterate test/case
 	$(MAKE) -C bench clean
 	$(MAKE) -C data clean
 
@@ -100,26 +101,29 @@ data/NormalizationTest.txt:
 data/GraphemeBreakTest.txt:
 	$(MAKE) -C data GraphemeBreakTest.txt
 
-test/normtest: test/normtest.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/normtest.c utf8proc.o -o $@
+test/tests.o: test/tests.c test/tests.h utf8proc.h
+	$(CC) $(UCFLAGS) -c -o test/tests.o test/tests.c
 
-test/graphemetest: test/graphemetest.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/graphemetest.c utf8proc.o -o $@
+test/normtest: test/normtest.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/normtest.c test/tests.o utf8proc.o -o $@
 
-test/printproperty: test/printproperty.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/printproperty.c utf8proc.o -o $@
+test/graphemetest: test/graphemetest.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/graphemetest.c test/tests.o utf8proc.o -o $@
 
-test/charwidth: test/charwidth.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/charwidth.c utf8proc.o -o $@
+test/printproperty: test/printproperty.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/printproperty.c test/tests.o utf8proc.o -o $@
 
-test/valid: test/valid.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/valid.c utf8proc.o -o $@
+test/charwidth: test/charwidth.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/charwidth.c test/tests.o utf8proc.o -o $@
 
-test/iterate: test/iterate.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/iterate.c utf8proc.o -o $@
+test/valid: test/valid.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/valid.c test/tests.o utf8proc.o -o $@
 
-test/case: test/case.c utf8proc.o utf8proc.h test/tests.h
-	$(CC) $(UCFLAGS) test/case.c utf8proc.o -o $@
+test/iterate: test/iterate.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/iterate.c test/tests.o utf8proc.o -o $@
+
+test/case: test/case.c test/tests.o utf8proc.o utf8proc.h test/tests.h
+	$(CC) $(UCFLAGS) test/case.c test/tests.o utf8proc.o -o $@
 
 check: test/normtest data/NormalizationTest.txt test/graphemetest data/GraphemeBreakTest.txt test/printproperty test/case test/charwidth test/valid test/iterate bench/bench.c bench/util.c bench/util.h utf8proc.o
 	$(MAKE) -C bench

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MAKE=make
 AR?=ar
 CC?=gcc
 INSTALL=install
+FIND=find
 
 # compiler settings
 CFLAGS ?= -O2
@@ -17,7 +18,7 @@ UCFLAGS = $(CFLAGS) $(PICFLAG) $(C99FLAG) $(WCFLAGS) -DUTF8PROC_EXPORTS
 # from the utf8proc version number because it indicates ABI compatibility,
 # not API compatibility: MAJOR should be incremented whenever *binary*
 # compatibility is broken, even if the API is backward-compatible
-# Be sure to also update these in CMakeLists.txt!
+# Be sure to also update these in MANIFEST and CMakeLists.txt!
 MAJOR=1
 MINOR=3
 PATCH=0
@@ -38,7 +39,7 @@ includedir=$(prefix)/include
 
 # meta targets
 
-.PHONY: all, clean, update, data
+.PHONY: all clean data update manifest install
 
 all: libutf8proc.a libutf8proc.$(SHLIB_EXT)
 
@@ -48,6 +49,7 @@ ifneq ($(OS),Darwin)
 	rm -f libutf8proc.so.$(MAJOR)
 endif
 	rm -f test/tests.o test/normtest test/graphemetest test/printproperty test/charwidth test/valid test/iterate test/case
+	rm -rf MANIFEST.new tmp
 	$(MAKE) -C bench clean
 	$(MAKE) -C data clean
 
@@ -55,6 +57,8 @@ data: data/utf8proc_data.c.new
 
 update: data/utf8proc_data.c.new
 	cp -f data/utf8proc_data.c.new utf8proc_data.c
+
+manifest: MANIFEST.new
 
 # real targets
 
@@ -92,6 +96,12 @@ install: libutf8proc.a libutf8proc.$(SHLIB_EXT) libutf8proc.$(SHLIB_VERS_EXT)
 ifneq ($(OS),Darwin)
 	ln -f -s libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.so.$(MAJOR)
 endif
+
+MANIFEST.new:
+	rm -rf tmp
+	$(MAKE) install prefix=/usr DESTDIR=$(PWD)/tmp
+	$(FIND) tmp/usr -mindepth 1 -type l -printf "%P -> %l\n" -or -type f -printf "%P\n" -or -type d -printf "%P/\n" | LC_ALL=C sort > $@
+	rm -rf tmp
 
 # Test programs
 

--- a/data/Makefile
+++ b/data/Makefile
@@ -59,4 +59,5 @@ GraphemeBreakTest.txt:
 	$(CURL) $(CURLFLAGS) $(URLCACHE)http://www.unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakTest.txt | $(PERL) -pe 's,÷,/,g;s,×,+,g' > $@
 
 clean:
-	rm -f UnicodeData.txt EastAsianWidth.txt DerivedCoreProperties.txt CompositionExclusions.txt CaseFolding.txt NormalizationTest.txt GraphemeBreakTest.txt CharWidths.txt unifont*.ttf unifont*.sfd
+	rm -f UnicodeData.txt EastAsianWidth.txt GraphemeBreakProperty.txt DerivedCoreProperties.txt CompositionExclusions.txt CaseFolding.txt NormalizationTest.txt GraphemeBreakTest.txt CharWidths.txt unifont*.ttf unifont*.sfd
+	rm -f utf8proc_data.c.new

--- a/test/charwidth.c
+++ b/test/charwidth.c
@@ -2,7 +2,7 @@
 #include <ctype.h>
 #include <wchar.h>
 
-int my_isprint(int c) {
+static int my_isprint(int c) {
      int cat = utf8proc_get_property(c)->category;
      return (UTF8PROC_CATEGORY_LU <= cat && cat <= UTF8PROC_CATEGORY_ZS) ||
           (c == 0x0601 || c == 0x0602 || c == 0x0603 || c == 0x06dd);

--- a/test/iterate.c
+++ b/test/iterate.c
@@ -8,7 +8,7 @@ static  int     error;
 #define CHECKVALID(pos, val, len) buf[pos] = val; testbytes(buf,len,len,__LINE__)
 #define CHECKINVALID(pos, val, len) buf[pos] = val; testbytes(buf,len,UTF8PROC_ERROR_INVALIDUTF8,__LINE__)
 
-void testbytes(unsigned char *buf, int len, utf8proc_ssize_t retval, int line)
+static void testbytes(unsigned char *buf, int len, utf8proc_ssize_t retval, int line)
 {
     utf8proc_int32_t out[16];
     utf8proc_ssize_t ret;

--- a/test/printproperty.c
+++ b/test/printproperty.c
@@ -7,7 +7,7 @@ int main(int argc, char **argv)
      int i;
 
      for (i = 1; i < argc; ++i) {
-          int c;
+          unsigned int c;
           if (!strcmp(argv[i], "-V")) {
                printf("utf8proc version %s\n", utf8proc_version());
                continue;

--- a/test/tests.c
+++ b/test/tests.c
@@ -1,0 +1,46 @@
+/* Common functions for our test programs. */
+
+#include "tests.h"
+
+size_t lineno = 0;
+
+void check(int cond, const char *format, ...)
+{
+     if (!cond) {
+          va_list args;
+          fprintf(stderr, "line %zd: ", lineno);
+          va_start(args, format);
+          vfprintf(stderr, format, args);
+          va_end(args);
+          fprintf(stderr, "\n");
+          exit(1);
+     }
+}
+
+size_t skipspaces(const char *buf, size_t i)
+{
+    while (isspace(buf[i])) ++i;
+    return i;
+}
+
+/* if buf points to a sequence of codepoints encoded as hexadecimal strings,
+   separated by whitespace, and terminated by any character not in
+   [0-9a-fA-F] or whitespace, then stores the corresponding utf8 string
+   in dest, returning the number of bytes read from buf */
+size_t encode(char *dest, const char *buf)
+{
+     size_t i = 0, j, d = 0;
+     for (;;) {
+          int c;
+          i = skipspaces(buf, i);
+          for (j=i; buf[j] && strchr("0123456789abcdef", tolower(buf[j])); ++j)
+               ; /* find end of hex input */
+          if (j == i) { /* no codepoint found */
+               dest[d] = 0; /* NUL-terminate destination string */
+               return i + 1;
+          }
+          check(sscanf(buf + i, "%x", (unsigned int *)&c) == 1, "invalid hex input %s", buf+i);
+          i = j; /* skip to char after hex input */
+          d += utf8proc_encode_char(c, (utf8proc_uint8_t *) (dest + d));
+     }
+}

--- a/test/tests.h
+++ b/test/tests.h
@@ -1,5 +1,13 @@
 /* Common functions and includes for our test programs. */
 
+/*
+ * Set feature macro to enable getline() and wcwidth().
+ *
+ * Please refer to section 2.2.1 of POSIX.1-2008:
+ * http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_02_01_02
+ */
+#define _XOPEN_SOURCE 700
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/test/tests.h
+++ b/test/tests.h
@@ -8,46 +8,8 @@
 
 #include "../utf8proc.h"
 
-size_t lineno = 0;
+extern size_t lineno;
 
-void check(int cond, const char *format, ...)
-{
-     if (!cond) {
-          va_list args;
-          fprintf(stderr, "line %zd: ", lineno);
-          va_start(args, format);
-          vfprintf(stderr, format, args);
-          va_end(args);
-          fprintf(stderr, "\n");
-          exit(1);
-     }
-}
-
-size_t skipspaces(const char *buf, size_t i)
-{
-    while (isspace(buf[i])) ++i;
-    return i;
-}
-
-/* if buf points to a sequence of codepoints encoded as hexadecimal strings,
-   separated by whitespace, and terminated by any character not in
-   [0-9a-fA-F] or whitespace, then stores the corresponding utf8 string
-   in dest, returning the number of bytes read from buf */
-size_t encode(char *dest, const char *buf)
-{
-     size_t i = 0, j, d = 0;
-     for (;;) {
-          int c;
-          i = skipspaces(buf, i);
-          for (j=i; buf[j] && strchr("0123456789abcdef", tolower(buf[j])); ++j)
-               ; /* find end of hex input */
-          if (j == i) { /* no codepoint found */
-               dest[d] = 0; /* NUL-terminate destination string */
-               return i + 1;
-          }
-          check(sscanf(buf + i, "%x", (unsigned int *)&c) == 1, "invalid hex input %s", buf+i);
-          i = j; /* skip to char after hex input */
-          d += utf8proc_encode_char(c, (utf8proc_uint8_t *) (dest + d));
-     }
-}
-
+void check(int cond, const char *format, ...);
+size_t skipspaces(const char *buf, size_t i);
+size_t encode(char *dest, const char *buf);


### PR DESCRIPTION
This commit series fixes several build warnings, and ensures that `make clean` reverts the build tree to a pristine state. This is the last pull request in an effort to bring utf8proc into shape for distribution packaging, specifically for Debian.