### PR TITLE
Version 1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project (utf8proc C)
 # Be sure to also update these in Makefile!
 set(SO_MAJOR 1)
 set(SO_MINOR 3)
-set(SO_PATCH 0)
+set(SO_PATCH 1)
 
 add_definitions (
   -DUTF8PROC_EXPORTS

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,6 @@ include/
 include/utf8proc.h
 lib/
 lib/libutf8proc.a
-lib/libutf8proc.so -> libutf8proc.so.1.3.0
-lib/libutf8proc.so.1 -> libutf8proc.so.1.3.0
-lib/libutf8proc.so.1.3.0
+lib/libutf8proc.so -> libutf8proc.so.1.3.1
+lib/libutf8proc.so.1 -> libutf8proc.so.1.3.1
+lib/libutf8proc.so.1.3.1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ UCFLAGS = $(CFLAGS) $(PICFLAG) $(C99FLAG) $(WCFLAGS) -DUTF8PROC_EXPORTS
 # Be sure to also update these in MANIFEST and CMakeLists.txt!
 MAJOR=1
 MINOR=3
-PATCH=0
+PATCH=1
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin) # MacOS X

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # utf8proc release history #
 
+## Version 1.3.1 ##
+
+2015-11-02:
+
+- Do not export symbol for internal function `unsafe_encode_char()` ([#55]).
+
+- Install relative symbolic links for shared libraries ([#58]).
+
+- Enable and fix compiler warnings ([#55], [#58]).
+
+- Add missing files to `make clean` ([#58]).
+
 ## Version 1.3 ##
 
 2015-07-06:
@@ -218,3 +230,5 @@ Release of version 1.0.1
 [#45]: https://github.com/JuliaLang/utf8proc/issues/45
 [#47]: https://github.com/JuliaLang/utf8proc/issues/47
 [#51]: https://github.com/JuliaLang/utf8proc/issues/51
+[#55]: https://github.com/JuliaLang/utf8proc/issues/55
+[#58]: https://github.com/JuliaLang/utf8proc/issues/58


### PR DESCRIPTION
It would be nice if you could tie a ribbon around #55, #56, #57, #58 by tagging a patch release. A tagged version makes it much easier to package utf8proc for Debian, which is a prerequisite for getting Julia 0.4.0 into Debian. I updated NEWS with all user-visible changes.
