### PR TITLE
Fix overrun

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project (utf8proc C)
 # Be sure to also update these in Makefile!
 set(SO_MAJOR 2)
 set(SO_MINOR 0)
-set(SO_PATCH 0)
+set(SO_PATCH 1)
 
 add_definitions (
   -DUTF8PROC_EXPORTS

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,6 @@ include/
 include/utf8proc.h
 lib/
 lib/libutf8proc.a
-lib/libutf8proc.so -> libutf8proc.so.2.0.0
-lib/libutf8proc.so.2 -> libutf8proc.so.2.0.0
-lib/libutf8proc.so.2.0.0
+lib/libutf8proc.so -> libutf8proc.so.2.0.1
+lib/libutf8proc.so.2 -> libutf8proc.so.2.0.1
+lib/libutf8proc.so.2.0.1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ UCFLAGS = $(CFLAGS) $(PICFLAG) $(C99FLAG) $(WCFLAGS) -DUTF8PROC_EXPORTS
 # Be sure to also update these in MANIFEST and CMakeLists.txt!
 MAJOR=2
 MINOR=0
-PATCH=0
+PATCH=1
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin) # MacOS X

--- a/test/iterate.c
+++ b/test/iterate.c
@@ -13,11 +13,17 @@ static void testbytes(unsigned char *buf, int len, utf8proc_ssize_t retval, int 
     utf8proc_int32_t out[16];
     utf8proc_ssize_t ret;
 
+    /* Make a copy to ensure that memory is left uninitialized after "len"
+     * bytes. This way, Valgrind can detect overreads.
+     */
+    unsigned char tmp[16];
+    memcpy(tmp, buf, len);
+
     tests++;
-    if ((ret = utf8proc_iterate(buf, len, out)) != retval) {
+    if ((ret = utf8proc_iterate(tmp, len, out)) != retval) {
         fprintf(stderr, "Failed (%d):", line);
         for (int i = 0; i < len ; i++) {
-            fprintf(stderr, " 0x%02x", buf[i]);
+            fprintf(stderr, " 0x%02x", tmp[i]);
         }
         fprintf(stderr, " -> %zd\n", ret);
         error++;

--- a/utf8proc.c
+++ b/utf8proc.c
@@ -128,7 +128,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_iterate(
   if ((uc - 0xc2) > (0xf4-0xc2)) return UTF8PROC_ERROR_INVALIDUTF8;
   if (uc < 0xe0) {         // 2-byte sequence
      // Must have valid continuation character
-     if (!utf_cont(*str)) return UTF8PROC_ERROR_INVALIDUTF8;
+     if (str >= end || !utf_cont(*str)) return UTF8PROC_ERROR_INVALIDUTF8;
      *dst = ((uc & 0x1f)<<6) | (*str & 0x3f);
      return 2;
   }


### PR DESCRIPTION
It went undetected so far because the corresponding test program was reusing the same initialized
memory buffer several times.