### PR TITLE
fix the travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
 env:
     # use JuliaLang caching (https://github.com/staticfloat/cache.julialang.org)
     # so that Travis builds do not depend on anyone's flaky servers but our own
-    - URLCACHE=https://cache.e.ip.saba.us/
+    - URLCACHE=https://cache.julialang.org/


### PR DESCRIPTION
certificate is expired on cache.e.ip.saba.us, it now lives at cache.julialang.org