### PR TITLE
Convert compiler warnings to errors for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
 env:
     # use JuliaLang caching (https://github.com/staticfloat/cache.julialang.org)
     # so that Travis builds do not depend on anyone's flaky servers but our own
-    - URLCACHE=https://cache.julialang.org/
+    - URLCACHE=https://cache.julialang.org/ CFLAGS="-O2 -Werror"


### PR DESCRIPTION
After the warning (#70) has been fixed, please merge to ensure warnings will never go unnoticed again.
```
cc -O2 -fPIC -std=c99 -Wall -Wmissing-prototypes -pedantic -DUTF8PROC_EXPORTS -c -o utf8proc.o utf8proc.c
utf8proc.c: In function ‘grapheme_break_extended’:
utf8proc.c:287:7: warning: variable ‘lbc_override’ set but not used [-Wunused-but-set-variable]
   int lbc_override = lbc;
       ^
```