### PR TITLE
Move -Wmissing-prototypes from Makefile to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
 env:
     # use JuliaLang caching (https://github.com/staticfloat/cache.julialang.org)
     # so that Travis builds do not depend on anyone's flaky servers but our own
-    - URLCACHE=https://cache.julialang.org/ CFLAGS="-O2 -Werror"
+    - URLCACHE=https://cache.julialang.org/ CFLAGS="-O2 -Werror -Wmissing-prototypes"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FIND=find
 CFLAGS ?= -O2
 PICFLAG = -fPIC
 C99FLAG = -std=c99
-WCFLAGS = -Wall -Wmissing-prototypes -pedantic
+WCFLAGS = -Wall -pedantic
 UCFLAGS = $(CFLAGS) $(PICFLAG) $(C99FLAG) $(WCFLAGS) -DUTF8PROC_EXPORTS
 
 # shared-library version MAJOR.MINOR.PATCH ... this may be *different*


### PR DESCRIPTION
since MSVC doesn't understand this flag, and the current
mechanism for building Julia with MSVC goes through the makefile

as suggested by @petercolberg at https://github.com/JuliaLang/utf8proc/pull/55#discussion_r71060437