### PR TITLE
use a different variable name for nested loop in bench.c

### DIFF
--- a/bench/bench.c
+++ b/bench/bench.c
@@ -7,7 +7,7 @@
 
 int main(int argc, char **argv)
 {
-	 int i;
+	 int i, j;
 	 int options = 0;
 	 
 	 for (i = 1; i < argc; ++i) {
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
 		  }
 		  uint8_t *dest;
 		  mytime start = gettime();
-		  for (int i = 0; i < 100; ++i) {
+		  for (j = 0; j < 100; ++j) {
 			   utf8proc_map(src, len, &dest, options);
 			   free(dest);
 		  }


### PR DESCRIPTION
and declare it ahead of time to avoid "error: 'for' loop initial declarations are only allowed in C99 mode"