### PR TITLE
Change UINT16_MAX macro to 65535U

### DIFF
--- a/utf8proc.h
+++ b/utf8proc.h
@@ -134,7 +134,7 @@ extern "C" {
 #endif
 
 #ifndef UINT16_MAX
-#  define UINT16_MAX ~(utf8proc_uint16_t)0
+#  define UINT16_MAX 65535U
 #endif
 
 /**


### PR DESCRIPTION
Change UINT16_MAX from `~(utf8proc_uint16_t)0` to fixed value `65535U` to prevent weird behaviour in complex expressions like in #82.
