### PR TITLE
Don't use cached version of UnicodeData.txt

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -38,7 +38,7 @@ CharWidths.txt: charwidths.jl unifont.sfd unifont_upper.sfd EastAsianWidth.txt
 UNICODE_VERSION=9.0.0
 
 UnicodeData.txt:
-	$(CURL) $(CURLFLAGS) -o $@ -O $(URLCACHE)http://www.unicode.org/Public/$(UNICODE_VERSION)/ucd/UnicodeData.txt
+	$(CURL) $(CURLFLAGS) -o $@ -O http://www.unicode.org/Public/$(UNICODE_VERSION)/ucd/UnicodeData.txt
 
 EastAsianWidth.txt:
 	$(CURL) $(CURLFLAGS) -o $@ -O $(URLCACHE)http://www.unicode.org/Public/$(UNICODE_VERSION)/ucd/EastAsianWidth.txt


### PR DESCRIPTION
Ref: https://github.com/JuliaLang/julia/pull/19725, UnicodeData.txt is now being cached in JuliaLang/julia's build. cc @tkelman 