### PR TITLE
Fixes allowing for “Full” folding and NFKC_CaseFold compliance.

### DIFF
--- a/data/data_generator.rb
+++ b/data/data_generator.rb
@@ -104,7 +104,7 @@ $excl_version = $excl_version.chomp.split("\n").collect { |e| e.hex }
 $case_folding_string = File.open("CaseFolding.txt", :encoding => 'utf-8').read
 $case_folding = {}
 $case_folding_string.chomp.split("\n").each do |line|
-  next unless line =~ /([0-9A-F]+); [CFS]; ([0-9A-F ]+);/i
+  next unless line =~ /([0-9A-F]+); [CF]; ([0-9A-F ]+);/i
   $case_folding[$1.hex] = $2.split(" ").collect { |e| e.hex }
 end
 

--- a/utf8proc.c
+++ b/utf8proc.c
@@ -422,7 +422,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_decompose_char(utf8proc_int32_t uc,
     if (!category) return UTF8PROC_ERROR_NOTASSIGNED;
   }
   if (options & UTF8PROC_IGNORE) {
-    if (property->ignorable) return 0;
+    if (!category || property->ignorable) return 0;
   }
   if (options & UTF8PROC_LUMP) {
     if (category == UTF8PROC_CATEGORY_ZS) utf8proc_decompose_lump(0x0020);


### PR DESCRIPTION
Changes:
* Only include `C` (Common) & `F` (Full) foldings from [CaseFolding.txt](http://unicode.org/Public/UCD/latest/ucd/CaseFolding.txt) data. Removed `S` (Simple) since `F` & `S` are specified to be exclusive. I'm not sure if it was causing issues, but it's technically an error.
* Extend `UTF8PROC_IGNORE` to also ignore unassigned codepoints (such as \u2065) which are specified as being discarded by NFKC_CF.

With these changes, compliant NFKC_CaseFolding should be achievable with the options `UTF8PROC_STABLE | UTF8PROC_COMPOSE | UTF8PROC_COMPAT | UTF8PROC_CASEFOLD | UTF8PROC_IGNORE`

_(This PR doesn't include the new `utf8proc_data.c` file since there's no point in generating it multiple times if changes are needed.)_
