### PR TITLE
Solved issue #118 "Missing VERSION_INFO when compiling as Windows DLL"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required (VERSION 2.8)
 
 include (utils.cmake)
 
+set(HASCMAKEHELPERS EXISTS "${CMAKE_SOURCE_DIR}/../CMakeHelpers/generate_product_version.cmake")
+
+if(${HASCMAKEHELPERS})
+  include ("${CMAKE_SOURCE_DIR}/../CMakeHelpers/generate_product_version.cmake")
+endif ()
+
 disallow_intree_builds()
 
 project (utf8proc C)
@@ -21,9 +27,19 @@ if (NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=c99 -pedantic -Wall")
 endif ()
 
+if(${HASCMAKEHELPERS})
+  generate_product_version(ProductVersionFiles
+    NAME utf8proc
+    VERSION_MAJOR ${SO_MAJOR}
+    VERSION_MINOR ${SO_MINOR}
+    VERSION_PATCH ${SO_PATCH}
+    COMPANY_NAME julialang.org)
+endif ()
+
 add_library (utf8proc
   utf8proc.c
   utf8proc.h
+  ${ProductVersionFiles}
 )
 
 set_target_properties (utf8proc PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,18 +21,7 @@ if (NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=c99 -pedantic -Wall")
 endif ()
 
-# https://cmake.org/Wiki/BuildingWinDLL
-# Allow the developer to select if Dynamic or Static libraries are built, default is static.
-OPTION (BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
-# Set the LIB_TYPE variable to STATIC
-SET (LIB_TYPE STATIC)
-IF (BUILD_SHARED_LIBS)
-  # User wants to build Dynamic Libraries, so change the LIB_TYPE variable to CMake keyword 'SHARED'
-  SET (LIB_TYPE SHARED)
-ENDIF (BUILD_SHARED_LIBS)
-
 add_library (utf8proc
-  ${LIB_TYPE}
   utf8proc.c
   utf8proc.h
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,18 @@ if (NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=c99 -pedantic -Wall")
 endif ()
 
+# https://cmake.org/Wiki/BuildingWinDLL
+# Allow the developer to select if Dynamic or Static libraries are built, default is static.
+OPTION (BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
+# Set the LIB_TYPE variable to STATIC
+SET (LIB_TYPE STATIC)
+IF (BUILD_SHARED_LIBS)
+  # User wants to build Dynamic Libraries, so change the LIB_TYPE variable to CMake keyword 'SHARED'
+  SET (LIB_TYPE SHARED)
+ENDIF (BUILD_SHARED_LIBS)
+
 add_library (utf8proc
+  ${LIB_TYPE}
   utf8proc.c
   utf8proc.h
 )


### PR DESCRIPTION
This solves JuliaLang/utf8proc issue #118 "Missing VERSION_INFO when compiling as Windows DLL" using CMakeHelpsers from https://github.com/halex2005/CMakeHelpers. CMakeHelpers must be place in the same directory as / parallel to utf8proc.
For English resource language you need to replace the following things in the CMakeHelpers/VersionResource.rc file:

FILEFLAGSMASK 0x3fL                    with   FILEFLAGSMASK 0x17
LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT with   LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
BLOCK "041904b0                        with   BLOCK "040704b0"
VALUE "Translation", 0x419, 1200       with   VALUE "Translation", 0x407, 1200