### PR TITLE
[CMake] Use target_compile_definitions to avoid affecting global definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.12)
 
 include (utils.cmake)
 
@@ -13,10 +13,6 @@ set(SO_MAJOR 2)
 set(SO_MINOR 1)
 set(SO_PATCH 0)
 
-add_definitions (
-  -DUTF8PROC_EXPORTS
-)
-
 if (NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=c99 -pedantic -Wall")
 endif ()
@@ -25,6 +21,8 @@ add_library (utf8proc
   utf8proc.c
   utf8proc.h
 )
+
+target_compile_definitions(utf8proc PRIVATE "UTF8PROC_EXPORTS")
 
 set_target_properties (utf8proc PROPERTIES
   POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
utf8proc's use of `add_definitions` affects the global definitions.

Instead, use `target_compile_definitions`.