### PR TITLE
`#define UTF8PROC_STATIC` to disable DLLEXPORT

### DIFF
--- a/utf8proc.h
+++ b/utf8proc.h
@@ -120,16 +120,20 @@ typedef bool utf8proc_bool;
 #endif
 #include <limits.h>
 
-#ifdef _WIN32
-#  ifdef UTF8PROC_EXPORTS
-#    define UTF8PROC_DLLEXPORT __declspec(dllexport)
-#  else
-#    define UTF8PROC_DLLEXPORT __declspec(dllimport)
-#  endif
-#elif __GNUC__ >= 4
-#  define UTF8PROC_DLLEXPORT __attribute__ ((visibility("default")))
-#else
+#ifdef UTF8PROC_STATIC
 #  define UTF8PROC_DLLEXPORT
+#else
+#  ifdef _WIN32
+#    ifdef UTF8PROC_EXPORTS
+#      define UTF8PROC_DLLEXPORT __declspec(dllexport)
+#    else
+#      define UTF8PROC_DLLEXPORT __declspec(dllimport)
+#    endif
+#  elif __GNUC__ >= 4
+#    define UTF8PROC_DLLEXPORT __attribute__ ((visibility("default")))
+#  else
+#    define UTF8PROC_DLLEXPORT
+#  endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is a simplified subset of #85 (also, see: #96) that enables compiling utf8proc without DLLEXPORT - without requiring the library consumer to modify the source files.

Simply `#define UTF8PROC_STATIC` when compiling to disable DLLEXPORT.