### PR TITLE
Enhance CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,13 @@ set_target_properties (utf8proc PROPERTIES
   VERSION "${SO_MAJOR}.${SO_MINOR}.${SO_PATCH}"
   SOVERSION ${SO_MAJOR}
 )
+
+install(TARGETS utf8proc
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+
+install(
+  FILES
+    "${PROJECT_SOURCE_DIR}/utf8proc.h"
+  DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ if (BUILD_SHARED_LIBS)
 else()
   # Building static library
   target_compile_definitions(utf8proc PUBLIC "UTF8PROC_STATIC")
+  if (MSVC)
+    set_target_properties(utf8proc PROPERTIES OUTPUT_NAME "utf8proc_static")
+  endif()
 endif()
 
 target_compile_definitions(utf8proc PRIVATE "UTF8PROC_EXPORTS")


### PR DESCRIPTION
- Add install target so that one can `nmake install` it in a specified `CMAKE_INSTALL_PREFIX`
- Suffix static library with '_static' in case the compiler is `MSVC`. Useful for packaging both shared and static libraries in Windows in a single tarball.